### PR TITLE
Replaced deprecated Biopython functions

### DIFF
--- a/functionTerms/basicTerms.py
+++ b/functionTerms/basicTerms.py
@@ -2,9 +2,18 @@ from openmm.app import *
 from openmm import *
 from openmm.unit import *
 import numpy as np
-from Bio.PDB.Polypeptide import one_to_three
+#from Bio.PDB.Polypeptide import one_to_three
+from Bio.PDB.Polypeptide import index_to_three, index_to_one, aa3, aa1
 import pandas as pd
-from Bio.PDB.Polypeptide import three_to_one
+#from Bio.PDB.Polypeptide import three_to_one
+
+# Bio.PDB.Polypeptide one_to_three and three_to_one are gone in Bio > 1.8
+# replacing as follows
+def one_to_three(res):
+  return index_to_three(aa1.index(res))
+
+def three_to_one(res):
+  return index_to_one(aa3.index(res))
 
 def con_term(oa, k_con=50208, bond_lengths=[.3816, .240, .276, .153], forceGroup=20):
     # add con forces

--- a/functionTerms/contactTerms.py
+++ b/functionTerms/contactTerms.py
@@ -5,8 +5,12 @@ from openmm.unit import *
 import numpy as np
 from openmm.unit.quantity import Quantity
 import pandas as pd
-from Bio.PDB.Polypeptide import three_to_one
+#from Bio.PDB.Polypeptide import three_to_one
+from Bio.PDB.Polypeptide import index_to_three, index_to_one, aa3, aa1
 
+
+def three_to_one(res):
+  return index_to_one(aa3.index(res))
 
 gamma_se_map_1_letter = {   'A': 0,  'R': 1,  'N': 2,  'D': 3,  'C': 4,
                             'Q': 5,  'E': 6,  'G': 7,  'H': 8,  'I': 9,


### PR DESCRIPTION
The three_to_one and one_to_three functions are no more. Defined new functions with those same names using biopython's alternative functions for contactTerms.py and basicTerms.py.